### PR TITLE
Added github repo and license type to metadata and tweaked Changes format

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module Sphinx::Config::Builder
 
+1.02
+    - Makefile.PL will now include github repo and license type in metadata
+    - Tweaked format of Changes file to conform to CPAN::Changes::Spec
+
 1.01  2013-10-29
     - tweaked POD
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,11 @@
 use 5.008008;
 
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
+if ($mm_ver =~ /_/) { # dev version
+    $mm_ver = eval $mm_ver;
+    die $@ if $@;
+}
+
 use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
@@ -10,4 +16,22 @@ WriteMakefile(
     ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
       (ABSTRACT_FROM  => 'lib/Sphinx/Config/Builder.pm', # retrieve abstract from module
        AUTHOR         => 'B. Estrade <estrabd@gmail.com>') : ()),
+
+    ($mm_ver >= 6.31
+        ? (LICENSE => 'perl')
+        : ()
+    ),
+
+    ($mm_ver <= 6.45 ? () : (META_MERGE => {
+        'meta-spec' => { version => 2 },
+        resources => {
+            bugtracker  => 'http://rt.cpan.org/Public/Dist/Display.html?Name=Sphinx-Config-Builder',
+            repository  => {
+                type => 'git',
+                web  => 'https://github.com/estrabd/perl-Sphinx-Config-Builder',
+                url  => 'git://github.com/estrabd/perl-Sphinx-Config-Builder.git',
+            },
+        },
+    })),
+
 );


### PR DESCRIPTION
Hi,

I've updated Makefile.PL so that the license type and github repo will be included in the metadata for your dist. This means MetaCPAN will be able to display this information, for example.

I've also tweaked the formatting of your Changes file to conform to CPAN::Changes::Spec. This means various tools can process your Changes file. For example MetaCPAN will be able to display the latest Changes along with your dist.

Cheers,
Neil
