### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/Sphinx-Config-Builder.t
+++ b/t/Sphinx-Config-Builder.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More;
 
 BEGIN {
-    use_ok( 'Sphinx::Config::Builder', q{Loading Sphinx::Config::Builder} );
+    use_ok( 'Sphinx::Config::Builder' );
 }
 
 my $builder = new_ok q{Sphinx::Config::Builder};


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.